### PR TITLE
Potential fix for code scanning alert no. 2: Exception text reinterpreted as HTML

### DIFF
--- a/server/routes/webhook.ts
+++ b/server/routes/webhook.ts
@@ -117,7 +117,7 @@ router.post("/webhook",
       event = stripe.webhooks.constructEvent(req.body, sig, endpointSecret);
     } catch (err: any) {
       console.error("❌ Webhook signature verification failed:", err.message);
-      return res.status(400).send(`Webhook Error: ${err.message}`);
+      return res.status(400).json({ error: `Webhook Error: ${err.message}` });
     }
 
     console.log(`✅ Received webhook event: ${event.type}`);


### PR DESCRIPTION
Potential fix for [https://github.com/Pawfect-Pixels-1/Pawfect-Pixelsapp/security/code-scanning/2](https://github.com/Pawfect-Pixels-1/Pawfect-Pixelsapp/security/code-scanning/2)

The correct general approach is to ensure error messages sent in HTTP responses are properly escaped for HTML, so that meta-characters (such as `<`, `>`, `&`, `'`, and `"`) in user-controlled input cannot break out of string boundaries and create executable markup (XSS). For Express, one best practice is to avoid sending string responses for errors and instead send a JSON object, since Express will serialize the data with correct escaping for safe display. Alternatively, explicitly escape the error string. 

**Best solution without altering endpoint behavior:**  
Change `res.status(400).send(`Webhook Error: ${err.message}`)` to send a JSON object with a key such as `error` containing the message text, e.g.  
`res.status(400).json({ error: `Webhook Error: ${err.message}` })`.  
This avoids HTML context entirely, as browsers do not render JSON as HTML, and trustworthy clients will process the response as JSON. This solution is concise, robust, and doesn't break the endpoint's purpose.

**File/region to change:**  
- `server/routes/webhook.ts`, line 120: change `.send()` to `.json({ error: ... })`

No additional imports are needed, and no change to surrounding code is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
